### PR TITLE
comply to the proper RFD specification

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -14,27 +14,27 @@
 
     <em:targetApplication>
       <!-- Thunderbird -->
-      <Description>
+      <RDF:Description>
         <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
         <em:minVersion>31.0</em:minVersion>
         <em:maxVersion>60.*</em:maxVersion>
-      </Description>
+      </RDF:Description>
     </em:targetApplication>
     <em:targetApplication>
       <!-- SeaMonkey -->
-      <Description>
+      <RDF:Description>
         <em:id>{92650c4d-4b8e-4d2a-b7eb-24ecf4f6b63a}</em:id>
         <em:minVersion>1.1</em:minVersion>
         <em:maxVersion>2.9.*</em:maxVersion>
-      </Description>
+      </RDF:Description>
     </em:targetApplication>
     <em:targetApplication>
       <!-- Postbox -->
-      <Description>
+      <RDF:Description>
         <em:id>postbox@postbox-inc.com</em:id>
         <em:minVersion>1.0b13</em:minVersion>
         <em:maxVersion>3.*</em:maxVersion>
-      </Description>
+      </RDF:Description>
     </em:targetApplication>
   </RDF:Description>
 </RDF:RDF>


### PR DESCRIPTION
Hi!

I fixed nostalgy in Debian yesterday and saw there is [a patch there][patch] that fixes `install.rfd` for it to use the proper RFD specification.

So here it is! Thanks for developing nostalgy.

[patch]: https://sources.debian.org/patches/nostalgy/0.2.36-1.1/0002-Fix-RDF-syntax.patch/ 